### PR TITLE
make "embrasure" command available in terminal

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log('Hello World!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,13 @@
             "license": "MIT",
             "dependencies": {
                 "aws-sdk": "^2.1474.0",
-                "ckey": "^1.0.3",
                 "dotenv": "^16.3.1",
                 "find-config": "^1.0.0",
                 "pg": "^8.11.3",
                 "sequelize": "^6.33.0"
+            },
+            "bin": {
+                "embrasure": "bin/index.js"
             },
             "devDependencies": {
                 "@babel/cli": "^7.23.0",
@@ -2685,23 +2687,6 @@
             },
             "engines": {
                 "node": ">= 6"
-            }
-        },
-        "node_modules/ckey": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ckey/-/ckey-1.0.3.tgz",
-            "integrity": "sha512-3R0DsI1Bysx1W0ufzFkuDrWpzu1oe8672EGz1zCvqC8QJx8ZafRJkeAWSRk38yQml8AkEkYGwkk2LEyHaJ8GAw==",
-            "dependencies": {
-                "dotenv": "^6.1.0",
-                "find-config": "^1.0.0"
-            }
-        },
-        "node_modules/ckey/node_modules/dotenv": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-            "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
         "url": "https://github.com/Embrasure-Secrets/embrasure/issues"
     },
     "homepage": "https://github.com/Embrasure-Secrets/embrasure#readme",
+    "bin": {
+        "embrasure": "./bin/index.js"
+    },
     "devDependencies": {
         "@babel/cli": "^7.23.0",
         "@babel/core": "^7.23.2",
@@ -34,7 +37,6 @@
     },
     "dependencies": {
         "aws-sdk": "^2.1474.0",
-        "ckey": "^1.0.3",
         "dotenv": "^16.3.1",
         "find-config": "^1.0.0",
         "pg": "^8.11.3",


### PR DESCRIPTION
First, in root directory, run command `npm link`

This makes bin field in package.json  expose module in bin folder to be available globally in the terminal.

Next, we can type "embrasure" in terminal and the module in bin folder will be executed.

Links below explain a bit more about npm link:
https://medium.com/@alexishevia/the-magic-behind-npm-link-d94dcb3a81af

https: //medium.com/netscape/a-guide-to-create-a-nodejs-command-line-package-c2166ad0452e