### PR TITLE
Aws housekeeping

### DIFF
--- a/src/utils/aws-init/createDBSubnets.js
+++ b/src/utils/aws-init/createDBSubnets.js
@@ -17,29 +17,18 @@ async function createSubnets(VpcId) {
         AvailabilityZone: `${region}b`,
         CidrBlock: '10.0.2.0/24',
     };
-    const subnetParams3 = {
-        VpcId,
-        AvailabilityZone: `${region}c`,
-        CidrBlock: '10.0.3.0/24',
-    };
 
     // build aws subnet creation command object
     const subnetCommand1 = new CreateSubnetCommand(subnetParams1);
     const subnetCommand2 = new CreateSubnetCommand(subnetParams2);
-    const subnetCommand3 = new CreateSubnetCommand(subnetParams3);
+
     try {
         // send subnet build request to aws
         const subnet1 = await client.send(subnetCommand1);
         console.log('Subnet 0 created');
         const subnet2 = await client.send(subnetCommand2);
         console.log('Subnet 1 created');
-        const subnet3 = await client.send(subnetCommand3);
-        console.log('Subnet 2 created');
-        const subnetIds = [
-            subnet1.Subnet.SubnetId,
-            subnet2.Subnet.SubnetId,
-            subnet3.Subnet.SubnetId,
-        ];
+        const subnetIds = [subnet1.Subnet.SubnetId, subnet2.Subnet.SubnetId];
         // Build and then send request to add name tags to each subnet
         subnetIds.forEach((id, idx) => {
             addNametag(id, `Embrasure-Subnet-${idx}`);

--- a/src/utils/aws-init/createVpcSecurityGroup.js
+++ b/src/utils/aws-init/createVpcSecurityGroup.js
@@ -10,8 +10,8 @@ async function createVpcSecurityGroup(vpcId) {
 
     // Specify name, description and associated vpc of new security group
     const params = {
-        GroupName: 'Embrasure-all-traffic',
-        Description: 'Embrasure created open security group that allows all traffic in',
+        GroupName: 'Embrasure-PostgreSQL-Traffic-Only',
+        Description: 'Embrasure created security group that only allows inbound postgresql traffic',
         VpcId: vpcId,
     };
     try {
@@ -24,9 +24,9 @@ async function createVpcSecurityGroup(vpcId) {
             GroupId: response.GroupId,
             IpPermissions: [
                 {
-                    IpProtocol: '-1',
-                    FromPort: -1,
-                    ToPort: -1,
+                    IpProtocol: 'tcp',
+                    FromPort: 5432,
+                    ToPort: 5432,
                     IpRanges: [{ CidrIp: '0.0.0.0/0' }],
                 },
             ],

--- a/src/utils/aws-init/init.js
+++ b/src/utils/aws-init/init.js
@@ -17,11 +17,9 @@ async function init() {
 
         const subnetGroupArr = await createSubnets(vpcId);
 
-        const privateSubnets = [subnetGroupArr[0], subnetGroupArr[1]];
-        // const publicSubnet = [subnetGroupArr[2]];
-        await createSubnetGroup(privateSubnets);
+        await createSubnetGroup(subnetGroupArr);
         await createPublicRouteTable(vpcId, internetGatewayId);
-        await createPrivateRouteTable(vpcId, subnetGroupArr); // all three subnets are intentionally placed on private route table
+        await createPrivateRouteTable(vpcId, subnetGroupArr); // all subnets are intentionally placed on private route table
 
         const securityGroupResponse = await createVpcSecurityGroup(vpcId);
         // wrapped in array beacuse createPostgresInstance expects array


### PR DESCRIPTION
Creates security group rule that limits inbound traffic to exclusively TCP to and from port 5432.

Removes unnecessary subnet-2 from being created with the rest of the backend architecture