### PR TITLE
Manage permissions

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,6 +22,7 @@ import {
     addUser,
     deleteUser,
     showPermissions,
+    editPermission,
 } from '../src/api/api.js';
 
 import initNewUser from '../src/aws/iam/initNewUser.js';
@@ -142,6 +143,21 @@ cli.command('sp')
             );
         } catch (error) {
             console.error("Couldn't show permissions of user");
+        }
+    });
+
+cli.command('ep')
+    .alias('editPermission')
+    .description('Edit read/write permission for a user')
+    .requiredOption('-n --name <name>', 'Specify username')
+    .option('-w --setWritePermission', 'Specify write permission', false)
+    .action(async ({ name, setWritePermission }) => {
+        const nameLowercase = name.toLowerCase();
+        try {
+            const editPermissionResult = await editPermission(nameLowercase, setWritePermission);
+            console.log(editPermissionResult);
+        } catch (error) {
+            console.error("Couldn't edit user write permission");
         }
     });
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,6 +21,7 @@ import {
     addSecret,
     addUser,
     deleteUser,
+    showPermissions,
 } from '../src/api/api.js';
 
 import initNewUser from '../src/aws/iam/initNewUser.js';
@@ -125,6 +126,22 @@ cli.command('au')
             console.log(usersCreated);
         } catch (error) {
             console.error("Couldn't add new user");
+        }
+    });
+
+cli.command('sp')
+    .alias('showPermissions')
+    .description('Show read/write permissions of a user')
+    .option('-n --name <name>', 'Specify username')
+    .action(async ({ name }) => {
+        const nameLowercase = name.toLowerCase();
+        try {
+            const permissions = await showPermissions(nameLowercase);
+            console.log(
+                `${name} has the following permissions for the Secrets table: ${permissions}`
+            );
+        } catch (error) {
+            console.error("Couldn't show permissions of user");
         }
     });
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -91,6 +91,15 @@ export const showPermissions = async (username) => {
     return permissions;
 };
 
+export const editPermission = async (username, setWritePermissionTo) => {
+    const { data: writePermission } = await axios.post(
+        `${ENDPOINT}/users/:username`,
+        { username, setWritePermissionTo },
+        { headers }
+    );
+    return writePermission;
+};
+
 export const deleteUser = async (username) => {
     const { data: usersDeleted } = await axios.delete(`${ENDPOINT}/users/${username}`, { headers });
     return usersDeleted;

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -86,6 +86,11 @@ export const addUser = async (username, hasWritePermissions) => {
     return usersCreated;
 };
 
+export const showPermissions = async (username) => {
+    const { data: permissions } = await axios.get(`${ENDPOINT}/users/${username}`, { headers });
+    return permissions;
+};
+
 export const deleteUser = async (username) => {
     const { data: usersDeleted } = await axios.delete(`${ENDPOINT}/users/${username}`, { headers });
     return usersDeleted;


### PR DESCRIPTION
The commits add 2 new features. One feature is for showing the database permissions of a user and the other feature is for editing the read/write database permission of a user.

If database user bob only has read access on the database and you run the following show permissions (sp) command:

embrasure sp -n bob

The following will be logged to the console:
bob has the following permissions for the Secrets table: SELECT

To grant bob write permission, run the following edit permission (ep) command:

embrasure ep -n bob -w

The following will be logged to the console:
{  writePermission: true }

If you run, embrasure sp -n bob again, the following is logged to the console:
bob has the following permissions for the Secrets table: INSERT, SELECT, UPDATE, DELETE

To revoke bob's write permission, run the following command:
embrasure ep -n bob

Then the following will be logged to the console:
{ writePermission: false }

Note that bob will still have read access to the database.